### PR TITLE
fix: blockquoteをライトモードに対応するように修正

### DIFF
--- a/src/components/blog/article/article.module.css
+++ b/src/components/blog/article/article.module.css
@@ -116,7 +116,14 @@
   padding: 1rem;
   border-radius: 0.25rem;
   border-left: 0.25rem solid var(--color-accent-primary);
-  background-color: var(--color-gray-600);
+}
+
+:global(.light) .content blockquote {
+  background-color: var(--color-gray-100);
+}
+
+:global(.dark) .content blockquote {
+  background-color: var(--color-gray-600)
 }
 
 .content blockquote > :global(*:first-child) {


### PR DESCRIPTION
<img width="612" alt="image" src="https://github.com/saitamau-maximum/blog/assets/32415464/362b6c13-db94-4fa7-b5b3-270055079bf9">
<img width="622" alt="image" src="https://github.com/saitamau-maximum/blog/assets/32415464/3b7892ad-7dec-4b4b-8f7c-fe5a26d9b5ce">
