### PR TITLE
fix: 横幅はみ出す系のデザインバグを修正

### DIFF
--- a/src/components/blog/article/article.module.css
+++ b/src/components/blog/article/article.module.css
@@ -43,6 +43,7 @@
   text-decoration: none;
   font-weight: 700;
   margin: 0 0.25rem;
+  word-break: break-word;
 }
 
 .content > :global(*:first-child) {
@@ -150,6 +151,7 @@
   border-spacing: 0;
   overflow: auto;
   margin: 1rem 0;
+  display: block;
 }
 
 .content table th,


### PR DESCRIPTION
`/blog/2024/intro-course/5/` を画面横幅の小さい端末 or Devtools 上で現行と Preview Deploy で見比べて貰えばわかります。

- リンクが長い場合の折り返し
- テーブルが長い時のスクロール設定

resolve #92 