### PR TITLE
fix: atcoderのリンクが表示されなくなっていたので差し替え

### DIFF
--- a/blog/2024/intro-course/0.md
+++ b/blog/2024/intro-course/0.md
@@ -136,7 +136,7 @@ chmod +x ./test
 
 ## AtCoderの登録
 
-<https://atcoder.jp/register?lang=ja>
+- [atcoderの登録](https://atcoder.jp/register?lang=ja)
 
 上記のリンクからAtCoderに登録してください．そこまで説明は必要ないかと思いますが，
 
@@ -151,4 +151,4 @@ chmod +x ./test
 せっかく環境が整ったので，皆さんが競プロを自習する際に参考になるサイトを紹介します．  
 まずは1章を進めていただければ，講習会の予習・復習にもなると思います．
 
-<https://atcoder.jp/contests/APG4b>
+- [APG4B](https://atcoder.jp/contests/APG4b)

--- a/blog/2024/intro-course/1.md
+++ b/blog/2024/intro-course/1.md
@@ -166,7 +166,7 @@ int main() {
 
 ### 問題
 
-<https://atcoder.jp/contests/abs/tasks/practice_1>
+- [練習問題](https://atcoder.jp/contests/abs/tasks/practice_1)
 
 整数 $a, b, c$ と文字列 $s$ が与えられるので、 $a + b + c$ と $s$ を並べて出力しなさい。
 
@@ -264,7 +264,7 @@ int main() {
 
 ### 問題
 
-<https://atcoder.jp/contests/abs/tasks/abc086_a>
+- [練習問題](https://atcoder.jp/contests/abs/tasks/abc086_a)
 
 $a, b$ の積が偶数か奇数かを判定するプログラムを書いてください。
 
@@ -378,7 +378,7 @@ int main() {
 
 ### 問題
 
-<https://atcoder.jp/contests/abs/tasks/abc081_a>
+- [練習問題](https://atcoder.jp/contests/abs/tasks/abc081_a)
 
 文字列$s$のうち、1 の個数を出力してください。
 
@@ -510,7 +510,7 @@ int main()　{
 
 ### 問題
 
-<https://atcoder.jp/contests/abs/tasks/abc081_b>
+- [練習問題](https://atcoder.jp/contests/abs/tasks/abc081_b)
 
 $N$個の正の整数$a_1, a_2, ..., a_N$が与えられます。これらの整数がすべて偶数なら、それぞれ 2 で割ったものに置き換えます。このとき、操作を行った回数の最小値を求めてください。
 

--- a/blog/2024/intro-course/2.md
+++ b/blog/2024/intro-course/2.md
@@ -62,7 +62,7 @@ int main() {
 
 ### 問題
 
-<https://atcoder.jp/contests/apg4b/tasks/APG4b_ci>
+- [練習問題](https://atcoder.jp/contests/apg4b/tasks/APG4b_ci)
 
 :::details[解答例]
 
@@ -143,7 +143,7 @@ int main() {
 
 この問題はすでにある程度書かれているプログラムに追記して完成させる問題です。関数を作らなくても解くことはできますが、使ってみましょう。
 
-<https://atcoder.jp/contests/apg4b/tasks/APG4b_ch>
+- [練習問題](https://atcoder.jp/contests/apg4b/tasks/APG4b_ch)
 
 :::details[解答例]
 
@@ -265,7 +265,7 @@ int main() {
 
 範囲for文やマクロを使った解き方や使わない解き方など、いろいろと考えてみてください。
 
-<https://atcoder.jp/contests/apg4b/tasks/APG4b_cg>
+- [練習問題](https://atcoder.jp/contests/apg4b/tasks/APG4b_cg)
 
 :::details[範囲for文やマクロなしの解答例]
 
@@ -373,7 +373,7 @@ i:2,j:2
 
 2重for文を使います。for文の中の変数が被らないように気を付けましょう。
 
-<https://atcoder.jp/contests/apg4b/tasks/APG4b_cf>
+- [練習問題](https://atcoder.jp/contests/apg4b/tasks/APG4b_cf)
 
 :::details[解答例]
 
@@ -417,7 +417,7 @@ int main() {
 
 2次元配列を出力する際、2重for文を使います。
 
-<https://atcoder.jp/contests/apg4b/tasks/APG4b_ce>
+- [練習問題](https://atcoder.jp/contests/apg4b/tasks/APG4b_ce)
 
 :::details[解答例]
 


### PR DESCRIPTION
講習会で使うブログを確認していたらatcoderのurlを貼ったlinkcardが使えなくなっていたので差し替えました